### PR TITLE
Resolve circular import for decorator

### DIFF
--- a/include/requireDevice.py
+++ b/include/requireDevice.py
@@ -1,0 +1,12 @@
+from functools import wraps
+
+# Require Device function decorator. Use this on any method that requires a device to be set
+def require_device(func):
+    @wraps(func)
+    def wrapper(self=None, *arg, **kwargs):
+        # Only run the decorated function if serial is open
+        if self.device.ser.is_open:
+            func(self, *arg, **kwargs)
+        else:
+            print("No device! Please connect to a device with \"connectDevice\"")
+    return wrapper

--- a/include/testCommand.py
+++ b/include/testCommand.py
@@ -5,7 +5,7 @@ sys.path.append('../')
 
 TESTPLAN_DIR = "testplans/"
 
-from rUI import require_device
+from include.requireDevice import require_device
 import tests
 
 

--- a/rUI.py
+++ b/rUI.py
@@ -2,21 +2,9 @@ from cmd import Cmd
 import include.strings as strings
 from include.device import Device
 import include.testCommand as testCommand
+from include.requireDevice import require_device
 from include.logger import logger
 import os.path, json
-from functools import wraps
-
-# Require Device function decorator. Use this on any method that requires a device to be set
-def require_device(func):
-    @wraps(func)
-    def wrapper(self=None, *arg, **kwargs):
-        # Only run the decorated function if serial is open
-        if self.device.ser.is_open:
-            func(self, *arg, **kwargs)
-        else:
-            print("No device! Please connect to a device with \"connectDevice\"")
-    return wrapper
-
 
 def setLocalOption(data):
     options = {}


### PR DESCRIPTION
Create a new file for the require_device decorator so that rUI.py and testCommand can use it without needing to import each other, which breaks the app on Python 3.6.